### PR TITLE
Add repository field to readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,9 @@
   },
   "main": "index.js",
   "license": "MIT",
-  "author": "ForbesLindesay"
+  "author": "ForbesLindesay",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ForbesLindesay/ajax.git"
+  }
 }


### PR DESCRIPTION
I am a bot.  I add repository fields to package.json files because they're super useful for npm.
