### PR TITLE
Allow overriding .xhr() function in options

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ var ajax = module.exports = function(options){
   var mime = settings.accepts[dataType],
       baseHeaders = { },
       protocol = /^([\w-]+:)\/\//.test(settings.url) ? RegExp.$1 : window.location.protocol,
-      xhr = ajax.settings.xhr(), abortTimeout
+      xhr = settings.xhr(), abortTimeout
 
   if (!settings.crossDomain) baseHeaders['X-Requested-With'] = 'XMLHttpRequest'
   if (mime) {


### PR DESCRIPTION
This seems like an oversight... you should be able to overwrite this function, especially if you want to use this with a mocking library like Mockjax.
