### PR TITLE
fix the delete callback bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,8 @@ ajax.JSONP = function(options){
     clearTimeout(abortTimeout)
       //todo: remove script
       //$(script).remove()
-    delete window[callbackName]
+    //delete window[callbackName]
+    if (callbackName in window) window[callbackName] = empty
     ajaxSuccess(data, xhr, options)
   }
 


### PR DESCRIPTION
when "window[callbackName]" is undefined "delete window[callbackName]" will cause error
test in IE8